### PR TITLE
Drop Markdown code fence from Mermaid output (#25)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  DEVELOPER_DIR: "/Applications/Xcode_15.0.1.app/Contents/Developer"
-
 jobs:
   unit_test:
     name: Test
-    runs-on: macos-13
+    runs-on: macos-latest
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/Plugins/Depermaid/Mermaid/Flowchart.swift
+++ b/Plugins/Depermaid/Mermaid/Flowchart.swift
@@ -18,12 +18,10 @@ struct Flowchart: Equatable {
     }
 
     func toString() -> String{
-        var mermaid = "```mermaid"
-        mermaid.newLine("flowchart \(self.direction)")
+        var mermaid = "flowchart \(self.direction)"
         items.forEach { item in
             mermaid.newLine(item.toString(), indent: 1)
         }
-        mermaid.newLine("```")
         return mermaid
     }
 }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Using depermaid allows you to continuously visualize the up-to-date state of you
 
     ```swift
     dependencies: [
-        .package(url: "https://github.com/daikimat/depermaid.git", from: "1.1.0")
+        .package(url: "https://github.com/daikimat/depermaid.git", from: "2.0.0")
     ],
     ```
 

--- a/Tests/DepermaidTests/MermaidTests.swift
+++ b/Tests/DepermaidTests/MermaidTests.swift
@@ -49,12 +49,10 @@ final class MermaidTests: XCTestCase {
         flowchart.append(Node("test2"), Node("test3"))
 
         let actual = """
-        ```mermaid
         flowchart TD
             test1
             test2
             test2-->test3
-        ```
         """
         XCTAssertEqual(flowchart.toString(), actual)
     }
@@ -63,45 +61,35 @@ final class MermaidTests: XCTestCase {
         let flowchartBT = Flowchart(direction: .BT)
 
         let actualBT = """
-        ```mermaid
         flowchart BT
-        ```
         """
         XCTAssertEqual(flowchartBT.toString(), actualBT)
 
         let flowchartLR = Flowchart(direction: .LR)
 
         let actualLR = """
-        ```mermaid
         flowchart LR
-        ```
         """
         XCTAssertEqual(flowchartLR.toString(), actualLR)
 
         let flowchartRL = Flowchart(direction: .RL)
 
         let actualRL = """
-        ```mermaid
         flowchart RL
-        ```
         """
         XCTAssertEqual(flowchartRL.toString(), actualRL)
 
         let flowchartTB = Flowchart(direction: .TB)
 
         let actualTB = """
-        ```mermaid
         flowchart TB
-        ```
         """
         XCTAssertEqual(flowchartTB.toString(), actualTB)
 
         let flowchartTD = Flowchart(direction: .TD)
 
         let actualTD = """
-        ```mermaid
         flowchart TD
-        ```
         """
         XCTAssertEqual(flowchartTD.toString(), actualTD)
     }

--- a/tool/syncExampleToReadme.sh
+++ b/tool/syncExampleToReadme.sh
@@ -1,33 +1,50 @@
 #!/bin/sh
 root=$(dirname $0)/..
+
+# Replace the interior of a ```mermaid ... ``` fenced block that follows a
+# given Markdown heading. The replacement is passed via the environment
+# (R) and the regex prefix via P, so neither is interpolated into the
+# Perl source — making this safe against $, @, \, / in plugin output.
+sync_block() {
+    prefix=$1
+    R=$2 P=$prefix perl -i -0777 -pe '
+        my $p = quotemeta($ENV{P});
+        s/(${p}.*?```mermaid\n)(.*?)(```)/$1$ENV{R}\n$3/s
+    ' $root/README.md
+}
+
 replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid)
 echo $replacement
-perl -i -0777 -pe "s/(\# Usage.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
+sync_block "# Usage" "$replacement"
 
 replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --test)
 echo $replacement
-perl -i -0777 -pe "s/(\# Including Test Targets.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
+sync_block "# Including Test Targets" "$replacement"
 
 replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --executable)
 echo $replacement
-perl -i -0777 -pe "s/(\# Including Executable Targets.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
+sync_block "# Including Executable Targets" "$replacement"
 
 replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --product)
 echo $replacement
-perl -i -0777 -pe "s/(\# Including Products.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
+sync_block "# Including Products" "$replacement"
 
 replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --test --executable --product)
 echo $replacement
-perl -i -0777 -pe "s/(\# Including All.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
+sync_block "# Including All" "$replacement"
 
 replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --direction TD --test --executable --product)
 echo $replacement
-perl -i -0777 -pe "s/(\# Direction.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
+sync_block "# Direction" "$replacement"
 
 replacement=$(swift package --package-path $root/Example/ComplexPackages depermaid LR)
 echo $replacement
-perl -i -0777 -pe "s/(\# Minimal Dependencies.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
+sync_block "# Minimal Dependencies" "$replacement"
 
+# The "--minimal" example is the *second* fenced block under "# Minimal
+# Dependencies", so we have to skip past the first one.
 replacement=$(swift package --package-path $root/Example/ComplexPackages depermaid --minimal)
 echo $replacement
-perl -i -0777 -pe "s/(\# Minimal Dependencies.*?\`\`\`mermaid.*?\`\`\`.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
+R=$replacement perl -i -0777 -pe '
+    s/(\# Minimal Dependencies.*?```mermaid.*?```.*?```mermaid\n)(.*?)(```)/$1$ENV{R}\n$3/s
+' $root/README.md

--- a/tool/syncExampleToReadme.sh
+++ b/tool/syncExampleToReadme.sh
@@ -2,32 +2,32 @@
 root=$(dirname $0)/..
 replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid)
 echo $replacement
-perl -i -0777 -pe "s/(\# Usage.*?)(\`\`\`mermaid.*?\`\`\`)/\$1$replacement/s" $root/README.md
+perl -i -0777 -pe "s/(\# Usage.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
 
 replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --test)
 echo $replacement
-perl -i -0777 -pe "s/(\# Including Test Targets.*?)(\`\`\`mermaid.*?\`\`\`)/\$1$replacement/s" $root/README.md
+perl -i -0777 -pe "s/(\# Including Test Targets.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
 
 replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --executable)
 echo $replacement
-perl -i -0777 -pe "s/(\# Including Executable Targets.*?)(\`\`\`mermaid.*?\`\`\`)/\$1$replacement/s" $root/README.md
+perl -i -0777 -pe "s/(\# Including Executable Targets.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
 
 replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --product)
 echo $replacement
-perl -i -0777 -pe "s/(\# Including Products.*?)(\`\`\`mermaid.*?\`\`\`)/\$1$replacement/s" $root/README.md
+perl -i -0777 -pe "s/(\# Including Products.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
 
 replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --test --executable --product)
 echo $replacement
-perl -i -0777 -pe "s/(\# Including All.*?)(\`\`\`mermaid.*?\`\`\`)/\$1$replacement/s" $root/README.md
+perl -i -0777 -pe "s/(\# Including All.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
 
 replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --direction TD --test --executable --product)
 echo $replacement
-perl -i -0777 -pe "s/(\# Direction.*?)(\`\`\`mermaid.*?\`\`\`)/\$1$replacement/s" $root/README.md
+perl -i -0777 -pe "s/(\# Direction.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
 
 replacement=$(swift package --package-path $root/Example/ComplexPackages depermaid LR)
 echo $replacement
-perl -i -0777 -pe "s/(\# Minimal Dependencies.*?)(\`\`\`mermaid.*?\`\`\`)/\$1$replacement/s" $root/README.md
+perl -i -0777 -pe "s/(\# Minimal Dependencies.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md
 
 replacement=$(swift package --package-path $root/Example/ComplexPackages depermaid --minimal)
 echo $replacement
-perl -i -0777 -pe "s/(\# Minimal Dependencies.*?\`\`\`mermaid.*?\`\`\`.*?)(\`\`\`mermaid.*?\`\`\`)/\$1$replacement/s" $root/README.md
+perl -i -0777 -pe "s/(\# Minimal Dependencies.*?\`\`\`mermaid.*?\`\`\`.*?\`\`\`mermaid\n)(.*?)(\`\`\`)/\$1$replacement\n\$3/s" $root/README.md


### PR DESCRIPTION
## Summary

- The plugin previously wrapped its output with a Markdown code fence (` ```mermaid ` … ` ``` `). That fence is Markdown — not Mermaid — so the output could not be piped directly into Mermaid tooling (`mmdc`, Mermaid Live Editor, `.mmd` files). Output is now raw Mermaid.
- Updated `tool/syncExampleToReadme.sh` so it captures the existing fence boundaries in `README.md` and replaces only the interior. The fences in `README.md` remain so GitHub continues to render the diagrams.

## Breaking change

Anyone who previously piped the plugin output straight into a Markdown file relied on the fence being included. They now need to wrap the output themselves:

```sh
{ echo '```mermaid'; swift package depermaid; echo '```'; } >> README.md
```

Closes #25.

## Test plan

- [x] `swift test` — all `MermaidTests` cases pass with fence-less expectations.
- [x] `tool/syncExampleToReadme.sh` runs cleanly and produces no diff against the current `README.md` (fences preserved, content identical).
- [x] Manually pipe output into `mmdc` to confirm Mermaid tooling accepts it directly.