### PR TITLE
Add --macro flag to include macro targets in the diagram

### DIFF
--- a/Example/AnimalPackages/Package.resolved
+++ b/Example/AnimalPackages/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Example/AnimalPackages/Package.swift
+++ b/Example/AnimalPackages/Package.swift
@@ -1,12 +1,15 @@
 // swift-tools-version: 5.9
 
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
     name: "ExampleDepermaidAnimalPackage",
+    platforms: [.macOS(.v10_15)],
     dependencies: [
         .package(path: "../../../depermaid"),
-        .package(path: "./Library")
+        .package(path: "./Library"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "509.0.0"),
     ],
     targets: [
         .target(
@@ -19,7 +22,8 @@ let package = Package(
         .target(
             name: "Cat",
             dependencies: [
-                "AnimalClient"
+                "AnimalClient",
+                "AnimalMacros"
             ]
         ),
         .target(
@@ -44,6 +48,13 @@ let package = Package(
             name: "ExecutableExample",
             dependencies: [
                 "Dog"
+            ]
+        ),
+        .macro(
+            name: "AnimalMacros",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
             ]
         ),
     ]

--- a/Example/AnimalPackages/Sources/AnimalMacros/AnimalMacros.swift
+++ b/Example/AnimalPackages/Sources/AnimalMacros/AnimalMacros.swift
@@ -1,0 +1,20 @@
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct StringifyMacro: ExpressionMacro {
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) -> ExprSyntax {
+        guard let argument = node.arguments.first?.expression else {
+            fatalError("compiler bug: the macro does not have any arguments")
+        }
+        return "(\(argument), \(literal: argument.description))"
+    }
+}
+
+@main
+struct AnimalMacrosPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [StringifyMacro.self]
+}

--- a/Plugins/Depermaid/Depermaid.swift
+++ b/Plugins/Depermaid/Depermaid.swift
@@ -57,7 +57,7 @@ struct Depermaid: CommandPlugin {
         includeMacro: Bool
     ) -> DependencyTree {
         var dependencyTree = DependencyTree()
-        sourceModules
+        let includedModules = sourceModules
             .filter { module in
                 return  switch (module.kind) {
                 case .generic:
@@ -79,6 +79,8 @@ struct Depermaid: CommandPlugin {
                     fatalError("unknown kind")
                 }
             }
+        let includedModuleNames = Set(includedModules.map(\.name))
+        includedModules
             .forEach { module in
                 switch (module.kind) {
                 case .generic:
@@ -103,8 +105,8 @@ struct Depermaid: CommandPlugin {
                 module.dependencies
                     .filter { dependencies in
                         switch dependencies {
-                        case .target(_):
-                            true
+                        case let .target(target):
+                            includedModuleNames.contains(target.name)
 
                         case .product(_):
                             includeProduct

--- a/Plugins/Depermaid/Depermaid.swift
+++ b/Plugins/Depermaid/Depermaid.swift
@@ -21,6 +21,7 @@ struct Depermaid: CommandPlugin {
                   --test                  Include .testTarget(name:...)
                   --executable            Include .executableTarget(name:...)
                   --product               Include .product(name:...)
+                  --include-macro         Include .macro(name:...)
                   --minimal               Generate a minimal Mermaid diagram by including only essential dependencies.
                   --help                  Show help information.
                 """
@@ -32,7 +33,8 @@ struct Depermaid: CommandPlugin {
             from: context.package.sourceModules,
             includeTest: (argExtractor.extractFlag(named: "test") > 0),
             includeExecutable: (argExtractor.extractFlag(named: "executable") > 0),
-            includeProduct: (argExtractor.extractFlag(named: "product") > 0)
+            includeProduct: (argExtractor.extractFlag(named: "product") > 0),
+            includeMacro: (argExtractor.extractFlag(named: "include-macro") > 0)
         )
 
         let direction = Direction(
@@ -51,7 +53,8 @@ struct Depermaid: CommandPlugin {
         from sourceModules: [SourceModuleTarget],
         includeTest: Bool,
         includeExecutable: Bool,
-        includeProduct: Bool
+        includeProduct: Bool,
+        includeMacro: Bool
     ) -> DependencyTree {
         var dependencyTree = DependencyTree()
         sourceModules
@@ -70,7 +73,7 @@ struct Depermaid: CommandPlugin {
                     false
 
                 case .macro:
-                    false
+                    includeMacro
 
                 @unknown default:
                     fatalError("unknown kind")
@@ -91,7 +94,7 @@ struct Depermaid: CommandPlugin {
                     break
 
                 case .macro:
-                    break
+                    dependencyTree.addDependency(from: Node(module.name, shape: .parallelogram))
 
                 @unknown default:
                     fatalError("unknown kind")

--- a/Plugins/Depermaid/Depermaid.swift
+++ b/Plugins/Depermaid/Depermaid.swift
@@ -21,7 +21,7 @@ struct Depermaid: CommandPlugin {
                   --test                  Include .testTarget(name:...)
                   --executable            Include .executableTarget(name:...)
                   --product               Include .product(name:...)
-                  --include-macro         Include .macro(name:...)
+                  --macro                 Include .macro(name:...)
                   --minimal               Generate a minimal Mermaid diagram by including only essential dependencies.
                   --help                  Show help information.
                 """
@@ -34,7 +34,7 @@ struct Depermaid: CommandPlugin {
             includeTest: (argExtractor.extractFlag(named: "test") > 0),
             includeExecutable: (argExtractor.extractFlag(named: "executable") > 0),
             includeProduct: (argExtractor.extractFlag(named: "product") > 0),
-            includeMacro: (argExtractor.extractFlag(named: "include-macro") > 0)
+            includeMacro: (argExtractor.extractFlag(named: "macro") > 0)
         )
 
         let direction = Direction(

--- a/Plugins/Depermaid/Mermaid/Node.swift
+++ b/Plugins/Depermaid/Mermaid/Node.swift
@@ -27,6 +27,8 @@ struct Node {
             "\(id)[[\(id)]]"
         case .hexagon:
             "\(id){{\(id)}}"
+        case .parallelogram:
+            "\(id)[/\(id)/]"
         }
     }
 }

--- a/Plugins/Depermaid/Mermaid/NodeShape.swift
+++ b/Plugins/Depermaid/Mermaid/NodeShape.swift
@@ -10,4 +10,5 @@ enum NodeShape {
     case stadium
     case subroutine
     case hexagon
+    case parallelogram
 }

--- a/README.md
+++ b/README.md
@@ -123,8 +123,6 @@ flowchart LR
 
 Macro targets are rendered with a parallelogram shape (`Name[/Name/]`).
 
-> **Note:** When a `.macro` target depends on swift-syntax 6xx products, those edges may not appear in the diagram. SwiftPM's `PackagePlugin` API does not expose those dependencies in that case, so depermaid cannot render them. See [#27](https://github.com/daikimat/depermaid/issues/27) for details.
-
 ### Including All
 
 Run the following command to include test targets, executable targets, products, and macro targets in the generated Mermaid diagram:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ flowchart LR
 Run the following command to include macro targets (`.macro(name:...)`) in the generated Mermaid diagram:
 
 ```bash
-$ swift package plugin depermaid --include-macro
+$ swift package plugin depermaid --macro
 ```
 
 ```mermaid
@@ -130,7 +130,7 @@ Macro targets are rendered with a parallelogram shape (`Name[/Name/]`).
 Run the following command to include test targets, executable targets, products, and macro targets in the generated Mermaid diagram:
 
 ```bash
-$ swift package plugin depermaid --test --executable --product --include-macro
+$ swift package plugin depermaid --test --executable --product --macro
 ```
 
 ```mermaid
@@ -152,7 +152,7 @@ flowchart LR
 You have the option to define the orientation of the generated Mermaid diagram by utilizing the --direction parameter. The available orientations are TD, TB(same as TD), BT, RL, LR. By default, it's set to LR."
 
 ```bash
-$ swift package plugin depermaid --direction TD --test --executable --product --include-macro
+$ swift package plugin depermaid --direction TD --test --executable --product --macro
 ```
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Using depermaid allows you to continuously visualize the up-to-date state of you
 flowchart LR
     AnimalClient
     Cat-->AnimalClient
+    Cat-->AnimalMacros
     Dog-->AnimalClient
     Example-->Cat
     Example-->Dog
@@ -62,6 +63,7 @@ flowchart LR
     AnimalClient
     AnimalClientTests{{AnimalClientTests}}-->AnimalClient
     Cat-->AnimalClient
+    Cat-->AnimalMacros
     Dog-->AnimalClient
     Example-->Cat
     Example-->Dog
@@ -79,6 +81,7 @@ $ swift package plugin depermaid --executable
 flowchart LR
     AnimalClient
     Cat-->AnimalClient
+    Cat-->AnimalMacros
     Dog-->AnimalClient
     Example-->Cat
     Example-->Dog
@@ -97,6 +100,7 @@ $ swift package plugin depermaid --product
 flowchart LR
     AnimalClient-->LifeCore[[LifeCore]]
     Cat-->AnimalClient
+    Cat-->AnimalMacros
     Dog-->AnimalClient
     Example-->Cat
     Example-->Dog
@@ -110,21 +114,35 @@ Run the following command to include macro targets (`.macro(name:...)`) in the g
 $ swift package plugin depermaid --include-macro
 ```
 
+```mermaid
+flowchart LR
+    AnimalClient
+    AnimalMacros[/AnimalMacros/]
+    Cat-->AnimalClient
+    Cat-->AnimalMacros
+    Dog-->AnimalClient
+    Example-->Cat
+    Example-->Dog
+```
+
 Macro targets are rendered with a parallelogram shape (`Name[/Name/]`).
 
 ### Including All
 
-Run the following command to include test targets, executable targets, and products in the generated Mermaid diagram:
+Run the following command to include test targets, executable targets, products, and macro targets in the generated Mermaid diagram:
 
 ```bash
-$ swift package plugin depermaid --test --executable --product
+$ swift package plugin depermaid --test --executable --product --include-macro
 ```
 
 ```mermaid
 flowchart LR
     AnimalClient-->LifeCore[[LifeCore]]
     AnimalClientTests{{AnimalClientTests}}-->AnimalClient
+    AnimalMacros[/AnimalMacros/]-->SwiftCompilerPlugin[[SwiftCompilerPlugin]]
+    AnimalMacros[/AnimalMacros/]-->SwiftSyntaxMacros[[SwiftSyntaxMacros]]
     Cat-->AnimalClient
+    Cat-->AnimalMacros
     Dog-->AnimalClient
     Example-->Cat
     Example-->Dog
@@ -136,14 +154,17 @@ flowchart LR
 You have the option to define the orientation of the generated Mermaid diagram by utilizing the --direction parameter. The available orientations are TD, TB(same as TD), BT, RL, LR. By default, it's set to LR."
 
 ```bash
-$ swift package plugin depermaid --direction TD --test --executable --product
+$ swift package plugin depermaid --direction TD --test --executable --product --include-macro
 ```
 
 ```mermaid
 flowchart TD
     AnimalClient-->LifeCore[[LifeCore]]
     AnimalClientTests{{AnimalClientTests}}-->AnimalClient
+    AnimalMacros[/AnimalMacros/]-->SwiftCompilerPlugin[[SwiftCompilerPlugin]]
+    AnimalMacros[/AnimalMacros/]-->SwiftSyntaxMacros[[SwiftSyntaxMacros]]
     Cat-->AnimalClient
+    Cat-->AnimalMacros
     Dog-->AnimalClient
     Example-->Cat
     Example-->Dog

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Using depermaid allows you to continuously visualize the up-to-date state of you
 flowchart LR
     AnimalClient
     Cat-->AnimalClient
-    Cat-->AnimalMacros
     Dog-->AnimalClient
     Example-->Cat
     Example-->Dog
@@ -63,7 +62,6 @@ flowchart LR
     AnimalClient
     AnimalClientTests{{AnimalClientTests}}-->AnimalClient
     Cat-->AnimalClient
-    Cat-->AnimalMacros
     Dog-->AnimalClient
     Example-->Cat
     Example-->Dog
@@ -81,7 +79,6 @@ $ swift package plugin depermaid --executable
 flowchart LR
     AnimalClient
     Cat-->AnimalClient
-    Cat-->AnimalMacros
     Dog-->AnimalClient
     Example-->Cat
     Example-->Dog
@@ -100,7 +97,6 @@ $ swift package plugin depermaid --product
 flowchart LR
     AnimalClient-->LifeCore[[LifeCore]]
     Cat-->AnimalClient
-    Cat-->AnimalMacros
     Dog-->AnimalClient
     Example-->Cat
     Example-->Dog

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ flowchart LR
 
 Macro targets are rendered with a parallelogram shape (`Name[/Name/]`).
 
+> **Note:** When a `.macro` target depends on swift-syntax 6xx products, those edges may not appear in the diagram. SwiftPM's `PackagePlugin` API does not expose those dependencies in that case, so depermaid cannot render them. See [#27](https://github.com/daikimat/depermaid/issues/27) for details.
+
 ### Including All
 
 Run the following command to include test targets, executable targets, products, and macro targets in the generated Mermaid diagram:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ flowchart LR
     Example-->Dog
 ```
 
+### Including Macro Targets
+
+Run the following command to include macro targets (`.macro(name:...)`) in the generated Mermaid diagram:
+
+```bash
+$ swift package plugin depermaid --include-macro
+```
+
+Macro targets are rendered with a parallelogram shape (`Name[/Name/]`).
+
 ### Including All
 
 Run the following command to include test targets, executable targets, and products in the generated Mermaid diagram:

--- a/Tests/DepermaidTests/MermaidTests.swift
+++ b/Tests/DepermaidTests/MermaidTests.swift
@@ -28,6 +28,10 @@ final class MermaidTests: XCTestCase {
         let hexagonNode = Node("hexagonNode", shape: .hexagon)
         let hexagonNodeActual = "hexagonNode{{hexagonNode}}"
         XCTAssertEqual(hexagonNode.toString(), hexagonNodeActual)
+
+        let parallelogramNode = Node("parallelogramNode", shape: .parallelogram)
+        let parallelogramNodeActual = "parallelogramNode[/parallelogramNode/]"
+        XCTAssertEqual(parallelogramNode.toString(), parallelogramNodeActual)
     }
 
     func testFlowChartItemToString() {

--- a/tool/syncExampleToReadme.sh
+++ b/tool/syncExampleToReadme.sh
@@ -29,11 +29,15 @@ replacement=$(swift package --package-path $root/Example/AnimalPackages depermai
 echo $replacement
 sync_block "# Including Products" "$replacement"
 
-replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --test --executable --product)
+replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --include-macro)
+echo $replacement
+sync_block "# Including Macro Targets" "$replacement"
+
+replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --test --executable --product --include-macro)
 echo $replacement
 sync_block "# Including All" "$replacement"
 
-replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --direction TD --test --executable --product)
+replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --direction TD --test --executable --product --include-macro)
 echo $replacement
 sync_block "# Direction" "$replacement"
 

--- a/tool/syncExampleToReadme.sh
+++ b/tool/syncExampleToReadme.sh
@@ -29,15 +29,15 @@ replacement=$(swift package --package-path $root/Example/AnimalPackages depermai
 echo $replacement
 sync_block "# Including Products" "$replacement"
 
-replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --include-macro)
+replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --macro)
 echo $replacement
 sync_block "# Including Macro Targets" "$replacement"
 
-replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --test --executable --product --include-macro)
+replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --test --executable --product --macro)
 echo $replacement
 sync_block "# Including All" "$replacement"
 
-replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --direction TD --test --executable --product --include-macro)
+replacement=$(swift package --package-path $root/Example/AnimalPackages depermaid --direction TD --test --executable --product --macro)
 echo $replacement
 sync_block "# Direction" "$replacement"
 


### PR DESCRIPTION
## Summary

Adds a new `--macro` flag that includes `.macro(name:...)` targets in the generated Mermaid diagram. Macro targets are rendered with a parallelogram shape (`Name[/Name/]`) so they are visually distinct from libraries (`square`), executables (`stadium`), tests (`hexagon`), and products (`subroutine`).

The example project (`Example/AnimalPackages`) gains a real `.macro` target (`AnimalMacros`) so the feature is exercised in the README's auto-generated diagrams.

## Behavior change beyond just adding the flag

Previously, `.target` edges were emitted unconditionally — even when the referenced module was excluded by another flag (or always-excluded like `.snippet`). For example, if `Cat` depended on `AnimalMacros`, the edge `Cat-->AnimalMacros` rendered even without `--macro`, producing a dangling default-shape node.

This PR makes flags govern both the **node** and its **incoming edges**: if a module is filtered out, edges pointing to it are dropped too. This mirrors how `.product` was already handled (no `--product` ⇒ no product edges) and removes dangling nodes for `.snippet`/excluded executables/tests as well.

## Changes

- `Plugins/Depermaid/Depermaid.swift` — new `--macro` flag, parallelogram shape for macro nodes, target-edge filtering against the included-module set
- `Plugins/Depermaid/Mermaid/{Node,NodeShape}.swift` — add `.parallelogram` shape (`Name[/Name/]`)
- `Tests/DepermaidTests/MermaidTests.swift` — test for the new shape
- `Example/AnimalPackages/Package.swift` + `Sources/AnimalMacros/AnimalMacros.swift` — sample `.macro` target with `Cat` depending on it
- `tool/syncExampleToReadme.sh` — sync `--macro` (and the All/Direction combos) into the README
- `README.md` — new "Including Macro Targets" section, updated combined examples

Related: #27 (closed; SwiftPM hides macro→swift-syntax product edges, judged not actionable).

## Test plan

- [x] `swift test` passes
- [x] Run the example project; confirm diagrams under each section render as expected
- [x] Confirm no dangling edges when a flag is off (e.g. default output no longer shows `Cat-->AnimalMacros`)
- [x] Manual review of README diagrams in the rendered Markdown